### PR TITLE
Fixed parse exception when parser has no options

### DIFF
--- a/src/main/scala/org/clapper/argot/Argot.scala
+++ b/src/main/scala/org/clapper/argot/Argot.scala
@@ -44,6 +44,7 @@ import scala.collection.mutable.{Map => MutableMap,
                                  LinkedHashMap,
                                  LinkedHashSet}
 import scala.util.matching.Regex
+import scala.util.Try
 import scala.annotation.tailrec
 
 /** Base trait for all option and parameter classes, `CommandLineArgument`
@@ -1169,7 +1170,7 @@ class ArgotParser(programName: String,
     val lengths: Iterable[Int] = for {opt  <- allOptions.values
                                       name <- opt.names}
                                    yield optString(name, opt).length
-    val maxOptLen = lengths.max
+    val maxOptLen = Try(lengths.max).getOrElse(0)
 
     // Create the output buffer.
 

--- a/src/test/scala/org/clapper/argot/ArgotParser/param.scala
+++ b/src/test/scala/org/clapper/argot/ArgotParser/param.scala
@@ -67,15 +67,22 @@ class ArgotParameterTest extends FunSuite {
 
   test("required argument failure") {
     val parser = new ArgotParser("test")
-    val opt = parser.option[String](
-      List("s", "something"), "something", "Some value"
-    )
     val req = parser.parameter[String]("foo", "some param", optional=false)
 
     val data = List(Array("-f"),
                     Array("-s"),
                     Array("-s", "something"),
                     Array.empty[String])
+
+    for (args <- data) {
+      intercept[ArgotUsageException] {
+        parser.parse(args)
+      }
+    }
+
+    val opt = parser.option[String](
+      List("s", "something"), "something", "Some value"
+    )
 
     for (args <- data) {
       intercept[ArgotUsageException] {


### PR DESCRIPTION
List.max will throw an UnsupportedOperationException if the list is
empty.
