### PR TITLE
Support GNU-style long options: --name=value

### DIFF
--- a/src/test/scala/org/clapper/argot/ArgotParser/option.scala
+++ b/src/test/scala/org/clapper/argot/ArgotParser/option.scala
@@ -51,7 +51,8 @@ class ArgotOptionTest extends FunSuite {
       (Some("something"),  Array("-s", "something")),
       (Some("foo"),        Array("--something", "foo")),
       (None,               Array.empty[String]),
-      (Some("bar"),        Array("-s", "foo", "-s", "bar"))
+      (Some("bar"),        Array("-s", "foo", "-s", "bar")),
+      (Some("baz"),        Array("--something=baz"))
     )
 
     for ((expected, args) <- data) {


### PR DESCRIPTION
The docs indicate that this style is not supported, but give no indication as to why. I have some utilities that use this style that I'd like to convert to use argot, and the lack of support for this `--name=value` format is the only thing preventing me from switching.