### PR TITLE
Upgrade to Scala 2.13.x, cross publish to 2.12, update deps.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,21 +13,21 @@ homepage := Some(url("http://software.clapper.org/argot/"))
 
 description := "A command-line option and parameter parser"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.13.1"
 
 // ---------------------------------------------------------------------------
 // Additional compiler options and plugins
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-crossScalaVersions := Seq("2.10.4", "2.11.5")
+crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.10")
 
 // ---------------------------------------------------------------------------
 // Dependendencies
 
 libraryDependencies ++= Seq(
-  "org.clapper" %% "grizzled-scala" % "1.3",
-  "org.scalatest" %% "scalatest" % "2.2.0" % "test"
+  "org.clapper" %% "grizzled-scala" % "4.9.3",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 // ---------------------------------------------------------------------------

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/src/main/scala/org/clapper/argot/Argot.scala
+++ b/src/main/scala/org/clapper/argot/Argot.scala
@@ -1163,8 +1163,6 @@ class ArgotParser(programName: String,
       }
     }
 
-    val mmax = MathUtil.max _
-
     // Calculate the maximum length of all the option strings.
 
     val lengths: Iterable[Int] = for {opt  <- allOptions.values
@@ -1300,14 +1298,14 @@ class ArgotParser(programName: String,
   -----------------------------------------------------------------------
    */
 
-  private def replaceOption(opt: CommandLineOption[_]) {
+  private def replaceOption(opt: CommandLineOption[_]): Unit = {
     opt.names.filter(_.length == 1).
     foreach(s => shortNameMap += s(0) -> opt)
     opt.names.filter(_.length > 1).foreach(s => longNameMap += s -> opt)
     allOptions += opt.name -> opt
   }
 
-  private def replaceParameter(param: Parameter[_]) {
+  private def replaceParameter(param: Parameter[_]): Unit = {
     parameters += param
   }
 

--- a/src/main/scala/org/clapper/argot/ArgotTest.scala
+++ b/src/main/scala/org/clapper/argot/ArgotTest.scala
@@ -63,7 +63,7 @@ object ArgotTest {
     file
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     try {
       parser.parse(args)


### PR DESCRIPTION
This PR bumps Argot to Scala 2.13.1 with cross publishing to the latest stable releases for 2.10.x, 2.11.x, and 2.12.x.

This also bumps sbt, switches to `sbt-bintray`, updates dependent libraries (scalatest, namely), and updates deprecated procedural syntax. I believe this can be published in its current state; if you encounter problems with bintray, please let me know and I'll do my best to update the branch.